### PR TITLE
chore: Add argocd 2.8 to CI

### DIFF
--- a/.github/workflows/assets/bootstrap/argocd-cmp-2.8/argo-cm.yml
+++ b/.github/workflows/assets/bootstrap/argocd-cmp-2.8/argo-cm.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  ui.bannercontent: "Security Goose says: This is a demo installation for the argocd-lovely-plugin. Not for production use."
+  ui.bannerpermanent: "true"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-cm

--- a/.github/workflows/assets/bootstrap/argocd-cmp-2.8/kustomization.yaml
+++ b/.github/workflows/assets/bootstrap/argocd-cmp-2.8/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+
+resources:
+- github.com/argoproj/argo-cd/manifests/cluster-install?ref=v2.8.0-rc1
+- namespace.yml
+
+patches:
+- path: argo-cm.yml
+  target:
+    kind: ConfigMap
+    name: argocd-cm
+- path: sidecar-plugin.yml
+  target:
+    kind: Deployment
+    name: argocd-repo-server

--- a/.github/workflows/assets/bootstrap/argocd-cmp-2.8/namespace.yml
+++ b/.github/workflows/assets/bootstrap/argocd-cmp-2.8/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd

--- a/.github/workflows/assets/bootstrap/argocd-cmp-2.8/sidecar-plugin.yml
+++ b/.github/workflows/assets/bootstrap/argocd-cmp-2.8/sidecar-plugin.yml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sidecar-plugin
+spec:
+  template:
+    spec:
+      containers:
+        - name: cmp
+          command: [/var/run/argocd/argocd-cmp-server] # Entrypoint should be Argo CD lightweight CMP server i.e. argocd-cmp-server
+          image: k3d-registry.localhost:5000/lovely
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+          volumeMounts:
+            - mountPath: /var/run/argocd
+              name: var-files
+            - mountPath: /home/argocd/cmp-server/plugins
+              name: plugins
+            # Starting with v2.4, do NOT mount the same tmp volume as the repo-server container. The filesystem separation helps 
+            # mitigate path traversal attacks.
+            - mountPath: /tmp
+              name: cmp-tmp
+      volumes:
+        - emptyDir: {}
+          name: cmp-tmp

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -73,6 +73,7 @@ jobs:
     strategy:
       matrix:
         argocd_version:
+          - "2.8"
           - "2.7"
           - "2.6"
       fail-fast: true


### PR DESCRIPTION
Adds the 2.8 release candidate to the CI so we get early badness warnings.