### PR TITLE
fix: make the sidecar examples work

### DIFF
--- a/examples/installation/argocd-sidecar-with-argocd-vault-plugin/argocd-lovely-plugin.yaml
+++ b/examples/installation/argocd-sidecar-with-argocd-vault-plugin/argocd-lovely-plugin.yaml
@@ -1,5 +1,4 @@
----
-# Downloads the argocd-vault-plugin and moves it to /custom-tools, which is then mounted on the sidecar.
+# Downloads the plugin and moves it to /custom-tools, which is then mounted on the argocd-repo-server
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,34 +6,13 @@ metadata:
 spec:
   template:
     spec:
-      # -- load env from secret
-      envFrom:
-        - secretRef:
-            name: vault-env
-      # -- init container to download vault plugin
-      initContainers:
-        - name: download-tools
-          image: registry.access.redhat.com/ubi8
-          env:
-            - name: AVP_VERSION
-              # renovate: datasource=github-releases depName=argoproj-labs/argocd-vault-plugin
-              value: 1.14.0
-          command: [sh, -c]
-          args:
-            - >-
-              curl -L https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v$(AVP_VERSION)/argocd-vault-plugin_$(AVP_VERSION)_linux_amd64 -o argocd-vault-plugin &&
-              chmod +x argocd-vault-plugin &&
-              mv argocd-vault-plugin /custom-tools/
-          volumeMounts:
-            - mountPath: /custom-tools
-              name: custom-tools
       containers:
         - name: lovely-plugin
           # This command is actually already set in the image.
           command: [/var/run/argocd/argocd-cmp-server] # Entrypoint should be Argo CD lightweight CMP server i.e. argocd-cmp-server
-          # Choose your image here - this one has vault replacer in it
-          image: ghcr.io/crumbhole/argocd-lovely-plugin-cmp-vault:0.17.0
-          # Here we are configuring default evironment for every app - in this case vault
+          # Choose your image here - this one has the Argo CD Vault plugin in it
+          image: ghcr.io/crumbhole/lovely-vault-plugin:0.19.7
+          # Here we are configuring default environment for every app - in this case vault
           envFrom:
             - secretRef:
                 name: vault-env
@@ -42,7 +20,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 999
           volumeMounts:
-            # Import the repo-server's plugin binary
+              # Import the repo-server's plugin binary
             - mountPath: /var/run/argocd
               name: var-files
             - mountPath: /home/argocd/cmp-server/plugins
@@ -51,13 +29,7 @@ spec:
               # mitigate path traversal attacks.
             - mountPath: /tmp
               name: lovely-tmp
-              # Mount the custom-tools volume, which contains the plugin binary.
-            - name: custom-tools
-              subPath: argocd-vault-plugin
-              mountPath: /usr/local/bin/argocd-vault-plugin
       volumes:
         # A temporary directory for the tool to work in.
         - emptyDir: {}
           name: lovely-tmp
-        - name: custom-tools
-          emptyDir: {}

--- a/examples/installation/argocd-sidecar/argocd-lovely-plugin.yaml
+++ b/examples/installation/argocd-sidecar/argocd-lovely-plugin.yaml
@@ -11,8 +11,8 @@ spec:
           # This command is actually already set in the image.
           command: [/var/run/argocd/argocd-cmp-server] # Entrypoint should be Argo CD lightweight CMP server i.e. argocd-cmp-server
           # Choose your image here - this one has vault replacer in it
-          image: ghcr.io/crumbhole/argocd-lovely-plugin-cmp-vault:0.17.0
-          # Here we are configuring default evironment for every app - in this case vault
+          image: ghcr.io/crumbhole/lovely-vault:0.19.7
+          # Here we are configuring default environment for every app - in this case vault
           envFrom:
             - secretRef:
                 name: vault-env
@@ -20,7 +20,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 999
           volumeMounts:
-              # Import the repo-server's pliugin binary
+              # Import the repo-server's plugin binary
             - mountPath: /var/run/argocd
               name: var-files
             - mountPath: /home/argocd/cmp-server/plugins


### PR DESCRIPTION
We were referencing old, test containers (that should probably be removed). 

We also didn't do a sidecar plugin in one of the sidecar plugin examples.