### PR TITLE
fix: correct vault plugin binary url. Fixes #235

### DIFF
--- a/variations/Dockerfile.vault-plugin
+++ b/variations/Dockerfile.vault-plugin
@@ -10,7 +10,7 @@ RUN yq -i e ".metadata.name |= \"${NAME}\"" /home/argocd/cmp-server/config/plugi
 RUN <<EOF
 	set -eux
 	apk add curl
-	curl -L https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/${AVP_VERSION}/argocd-vault-plugin_$(echo ${AVP_VERSION}|tr -d v)_linux_amd64 -o /usr/local/bin/argocd-vault-plugin
+	curl -L https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/${AVP_VERSION}/argocd-vault-plugin_$(echo ${AVP_VERSION}|tr -d v)_linux_${TARGETARCH} -o /usr/local/bin/argocd-vault-plugin
 	chmod +x /usr/local/bin/argocd-vault-plugin
 EOF
 USER 999

--- a/variations/Dockerfile.vault-plugin
+++ b/variations/Dockerfile.vault-plugin
@@ -5,7 +5,7 @@ ARG NAME
  # https://github.com/argoproj-labs/argocd-vault-plugin/releases
  # renovate: datasource=github-releases depName=argoproj-labs/argocd-vault-plugin
 ARG AVP_VERSION=v1.14.0
-ARG TARGETPLATFORM
+ARG TARGETARCH
 USER 0
 RUN yq -i e ".metadata.name |= \"${NAME}\"" /home/argocd/cmp-server/config/plugin.yaml
 RUN <<EOF

--- a/variations/Dockerfile.vault-plugin
+++ b/variations/Dockerfile.vault-plugin
@@ -5,6 +5,7 @@ ARG NAME
  # https://github.com/argoproj-labs/argocd-vault-plugin/releases
  # renovate: datasource=github-releases depName=argoproj-labs/argocd-vault-plugin
 ARG AVP_VERSION=v1.14.0
+ARG TARGETPLATFORM
 USER 0
 RUN yq -i e ".metadata.name |= \"${NAME}\"" /home/argocd/cmp-server/config/plugin.yaml
 RUN <<EOF

--- a/variations/Dockerfile.vault-plugin
+++ b/variations/Dockerfile.vault-plugin
@@ -10,7 +10,7 @@ RUN yq -i e ".metadata.name |= \"${NAME}\"" /home/argocd/cmp-server/config/plugi
 RUN <<EOF
 	set -eux
 	apk add curl
-	curl -L https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v${AVP_VERSION}/argocd-vault-plugin_$(echo ${AVP_VERSION}|tr -d v)_linux_amd64 -o /usr/local/bin/argocd-vault-plugin
+	curl -L https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/${AVP_VERSION}/argocd-vault-plugin_$(echo ${AVP_VERSION}|tr -d v)_linux_amd64 -o /usr/local/bin/argocd-vault-plugin
 	chmod +x /usr/local/bin/argocd-vault-plugin
 EOF
 USER 999


### PR DESCRIPTION
fixes:

- Correctly downloads the vault plugin binary into the container
- Makes the container truly multiarch (amd64 && arm64)