### PR TITLE
feat: add built-in ytt

### DIFF
--- a/variations/Dockerfile.ytt
+++ b/variations/Dockerfile.ytt
@@ -1,0 +1,17 @@
+ARG VERSION
+ARG PARENT
+FROM ${PARENT}:${VERSION}
+ARG NAME
+ # https://github.com/carvel-dev/ytt/releases
+ # renovate: datasource=github-releases depName=carvel-dev/ytt
+ARG YTT_VERSION=v0.45.4
+ARG TARGETARCH
+ENV PLUGIN_NAME="${NAME}"
+USER 0
+RUN <<EOF
+    set -eux
+    apk add curl
+    curl -L https://github.com/carvel-dev/releases/download/${YTT_VERSION}/ytt-linux-${TARGETARCH} -o /usr/local/bin/ytt
+    chmod +x /usr/local/bin/ytt
+EOF
+USER 999

--- a/variations/variations.txt
+++ b/variations/variations.txt
@@ -10,3 +10,5 @@ lovely-hera-vault-ver lovely-hera-ver Dockerfile.vault
 lovely-hera-vault lovely-hera-vault-ver Dockerfile.nover
 lovely-hera-vault-plugin-ver lovely-hera-ver Dockerfile.vault-plugin
 lovely-hera-vault-plugin lovely-hera-vault-plugin-ver Dockerfile.nover
+lovely-ytt-ver BASE Dockerfile.ytt
+lovely-ytt lovely-ytt-ver Dockerfile.nover


### PR DESCRIPTION
[ytt](https://github.com/carvel-dev/ytt) is a yaml templating tool which permits advanced YAML templating and substituting data from env variables, [amongst other](https://carvel.dev/ytt/docs/v0.44.0/yaml-primer/)

it would permit replacing [another plugin I had written](https://github.com/postfinance/argocd-cmp-ytt/) specifically for this use case

also, the `ytt` binary is quite small (15MB) so it shouldn't be an issue including it per-default.