### PR TITLE
fix: Remove legacy evidence of non-sidecar stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ ENV LOVELY_HELMFILE_PATH=/usr/local/bin/helmfile
 ENV LOVELY_KUSTOMIZE_PATH=/usr/local/bin/kustomize
 ENV LOVELY_PLUGINS=
 ENV LOVELY_PREPROCESSORS=
-ENV LOVELY_SIDECAR=true
 COPY --from=builder /usr/local/bin/yq /usr/local/bin/yq
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
 COPY --from=builder /usr/local/bin/helmfile /usr/local/bin/helmfile

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ We aim to match the [Argo CD supported versions](https://argo-cd.readthedocs.io/
 We offer many pre-built container options. We only support the use of these containers, the binaries provided are for convenience:
 
 - `argocd-lovely-plugin-cmp` to install as a sidecar plugin, which is versioned.
-- The deprecated `argocd-lovely-plugin` if you wish to install as an older-style configMap plugin.
-- [Variations](doc/variations.md) lists many other versions of the plugin, and explains versioning
+- [Variations](doc/variations.md) lists many other versions of the plugin, and explains versioning.
 
 ## Installing as an Argo CD Sidecar Plugin
 We recommend you install as an Argo CD CMP Sidecar Plugin. [Argo CD's documentation](https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/#sidecar-plugin) has steps on how to achieve this, or you can see [our Kustomization example](examples/installation). You can also observe how we install Lovely for our CI tests in the [CI bootstrap directory](.github/workflows/assets/bootstrap) in this repo.
@@ -56,7 +55,7 @@ For more information, please refer to the [Argo CD Documentation on discovery](h
 
 ## Environment variables
 
-argocd-lovely-plugin is configured through environment variables and parameters. These can be set in both the sidecar (or for configmaps, the argocd-repo-server) and in the application itself.
+argocd-lovely-plugin is configured through environment variables and parameters. These can be set in both the sidecar and in the application itself.
 
 If you are passing the configuration in as application environment variables in Argo CD 2.4 or higher you must not put the `ARGOCD_ENV_` prefix on them, as Argo CD does that for you.
 

--- a/cmd/argocd-lovely-plugin/main_test.go
+++ b/cmd/argocd-lovely-plugin/main_test.go
@@ -138,19 +138,8 @@ func testDirs(t *testing.T, path string, errorsExpected bool) {
 	}
 }
 
-// Tests with copy
-func TestDirectoriesCopy(t *testing.T) {
-	testDirs(t, normalPath, false)
-}
-
-// Tests with git checkout/clean
-func TestDirectoriesGitCheckout(t *testing.T) {
-	t.Setenv(`LOVELY_ALLOW_GITCHECKOUT`, `true`)
-	testDirs(t, normalPath, false)
-}
-
-// Test as sidecar
-func TestDirectoriesSidecar(t *testing.T) {
+// Test as sidecar only
+func TestDirectories(t *testing.T) {
 	os.RemoveAll(copyPath)
 	opt := copy.Options{
 		OnDirExists: func(_ string, _ string) copy.DirExistsAction {
@@ -161,7 +150,6 @@ func TestDirectoriesSidecar(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	t.Setenv(`LOVELY_SIDECAR`, `true`)
 	testDirs(t, copyPath, false)
 	os.RemoveAll(copyPath)
 }

--- a/doc/.snippets/parameterFooter.md
+++ b/doc/.snippets/parameterFooter.md
@@ -1,3 +1,3 @@
 ## Plugin Name
 
-For sidecar images only you can set `PLUGIN_NAME` in the environment of the sidecar to override the default name of the plugin. This allows you to supply multiple pre-configured plugins (with different environment, but the same variation).
+You can set `PLUGIN_NAME` in the environment of the sidecar to override the default name of the plugin. This allows you to supply multiple pre-configured plugins (with different environment, but the same variation).

--- a/doc/how.md
+++ b/doc/how.md
@@ -26,18 +26,7 @@ flowchart LR
 
 ## Ensuring a clean copy
 
-Lovely's processing of a sub-application can modify files. As modifications made may not be idempotent, we need to ensure we are working on an unmodified copy of the files. Lovely has 3 strategies for dealing with this:
-* Sidecar: When running as a sidecar, we get a fresh copy, so lovely doesn't do anything special. The sidecar images set `LOVELY_SIDECAR=true`.
-* Configmap plugin: Normally lovely will copy the sub-application folder only to a temporary folder and process them there. This means that if you refer to files outside the sub-application folder then it will not work.
-* Configmap plugin with `LOVELY_ALLOW_GITCHECKOUT=true`. In this case we will perform a git checkout after processing to undo any changes made by lovely. Check [this documentation](doc/allow_git.md).
-
-```mermaid
-flowchart LR
-    start{LOVELY_SIDECAR} -->|true| nothing["Do no special process"]
-	start -->|not true| check{LOVELY_ALLOW_GITCHECKOUT}
-	check -->|not true| copy[Copy files to temporary dir]
-	check -->|true| git[Git checkout at end]
-```
+Lovely's processing of a sub-application can modify files. As modifications made may not be idempotent, we need to ensure we are working on an unmodified copy of the files. When running as a sidecar, we get a fresh copy, so lovely doesn't do anything special.
 
 ## Processing
 

--- a/doc/parameter.md
+++ b/doc/parameter.md
@@ -31,7 +31,7 @@ Environment variables, are conventionally ALL_CAPS, and for our purposes
 | Helm Repo Add Parameters | LOVELY_HELM_REPO_ADD_PARAMS | Space separated extra parameters to `Helm repo add` as you might use on the command line. You're on your own here if you pass rubbish parameters. `--insecure-skip-tls-verify` if your helm chart is on an insecure HTTPS server. |  |
 | Kustomize Merge | LOVELY_KUSTOMIZE_MERGE | Set to some yaml you'd like [strategic merged](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesstrategicmerge/) into any kustomization.yaml found. |  |
 | Kustomize Patch | LOVELY_KUSTOMIZE_PATCH | Set to some yaml or json you'd like [json6902](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesjson6902/) patched into any kustomization.yaml found. |  |
-| Allow Git Checkout | LOVELY_ALLOW_GITCHECKOUT | This is not necessary when using the plugin as a sidecar. Allows kustomize base paths to work. Do **not** just set this without reading [the documentation](allow_git.md) | false |
+|  |  |  |  |
 | Helm Name | LOVELY_HELM_NAME | This can be used to set the Helm 'name' in the same way as releaseName works in Argo CD's standard Helm processing. (`ARGOCD_APP_NAME` used to be overridable in old versions of ArgoCD, but is no longer). Will default to ARGOCD_APP_NAME from the application. |  |
 | Helm Namespace | LOVELY_HELM_NAMESPACE |  This can be used to set the Helm 'namespace' it will apply. Will default to ARGOCD_APP_NAMESPACE from the application. |  |
 | Helm Values | LOVELY_HELM_VALUES | This is a space separated list values files you'd like to use when rendering the helm chart. Defaults to `values.yaml` if that exists, but its fine if it doesn't. If you override this the file *must* exist. MERGE and PATCH will be applied to the first file in this list. |  |
@@ -41,4 +41,4 @@ Environment variables, are conventionally ALL_CAPS, and for our purposes
 | Helmfile Template Parameters | LOVELY_HELMFILE_TEMPLATE_PARAMS | Space separated extra parameters to `Helmfile template` as you might use on the command line. You're on your own here if you pass rubbish parameters. |  |
 ## Plugin Name
 
-For sidecar images only you can set `PLUGIN_NAME` in the environment of the sidecar to override the default name of the plugin. This allows you to supply multiple pre-configured plugins (with different environment, but the same variation).
+You can set `PLUGIN_NAME` in the environment of the sidecar to override the default name of the plugin. This allows you to supply multiple pre-configured plugins (with different environment, but the same variation).

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -134,12 +134,6 @@ func Features() map[FeatureID]Feature {
 			Name:        `lovely_kustomize_patch`,
 			Description: "Set to some yaml or json you'd like [json6902](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesjson6902/) patched into any kustomization.yaml found.",
 		},
-		AllowGitCheckout: {
-			Title:       `Allow Git Checkout`,
-			Name:        `lovely_allow_gitcheckout`,
-			DefaultVal:  `false`,
-			Description: `This is not necessary when using the plugin as a sidecar. Allows kustomize base paths to work. Do **not** just set this without reading [the documentation](allow_git.md)`,
-		},
 		HelmName: {
 			Title:       `Helm Name`,
 			Name:        `lovely_helm_name`,

--- a/pkg/features/getters.go
+++ b/pkg/features/getters.go
@@ -5,7 +5,6 @@ package features
 import (
 	"github.com/crumbhole/argocd-lovely-plugin/pkg/config"
 	"os"
-	"strconv"
 )
 
 // GetPlugins returns the list of plugins to run during the generate phase after main processing
@@ -102,17 +101,6 @@ func GetKustomizeMerge() string {
 func GetKustomizePatch() string {
 	f := Features()[KustomizePatch]
 	return config.GetStringParam(f.EnvName(), f.DefaultVal)
-}
-
-// GetAllowGitCheckout establishes if git is safe to use
-// Set ALLOW_GITCHECKOUT to true to say you've told Argo this is safe
-func GetAllowGitCheckout() bool {
-	f := Features()[AllowGitCheckout]
-	res, err := strconv.ParseBool(config.GetStringParam(f.EnvName(), f.DefaultVal))
-	if err != nil {
-		return false
-	}
-	return res
 }
 
 // GetHelmName gives us the application name for helm


### PR DESCRIPTION
This change ensures lovely will misbehave when run as a legacy plugin.