### PR TITLE
ci: Test against argocd 2.10 RCs

### DIFF
--- a/.github/workflows/assets/bootstrap/argocd-cmp-2.10/argo-cm.yml
+++ b/.github/workflows/assets/bootstrap/argocd-cmp-2.10/argo-cm.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  ui.bannercontent: "Security Goose says: This is a demo installation for the argocd-lovely-plugin. Not for production use."
+  ui.bannerpermanent: "true"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-cm

--- a/.github/workflows/assets/bootstrap/argocd-cmp-2.10/kustomization.yaml
+++ b/.github/workflows/assets/bootstrap/argocd-cmp-2.10/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+
+resources:
+- github.com/argoproj/argo-cd/manifests/cluster-install?ref=v2.10.0-rc1
+- namespace.yml
+
+patches:
+- path: argo-cm.yml
+  target:
+    kind: ConfigMap
+    name: argocd-cm
+- path: sidecar-plugin.yml
+  target:
+    kind: Deployment
+    name: argocd-repo-server

--- a/.github/workflows/assets/bootstrap/argocd-cmp-2.10/namespace.yml
+++ b/.github/workflows/assets/bootstrap/argocd-cmp-2.10/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd

--- a/.github/workflows/assets/bootstrap/argocd-cmp-2.10/sidecar-plugin.yml
+++ b/.github/workflows/assets/bootstrap/argocd-cmp-2.10/sidecar-plugin.yml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sidecar-plugin
+spec:
+  template:
+    spec:
+      containers:
+        - name: cmp
+          image: k3d-registry.localhost:5000/lovely
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+          volumeMounts:
+            - mountPath: /var/run/argocd
+              name: var-files
+            - mountPath: /home/argocd/cmp-server/plugins
+              name: plugins
+            # Starting with v2.4, do NOT mount the same tmp volume as the repo-server container. The filesystem separation helps
+            # mitigate path traversal attacks.
+            - mountPath: /tmp
+              name: cmp-tmp
+      volumes:
+        - emptyDir: {}
+          name: cmp-tmp

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -73,6 +73,7 @@ jobs:
     strategy:
       matrix:
         argocd_version:
+          - "2.10"
           - "2.9"
           - "2.8"
       fail-fast: true

--- a/renovate.json
+++ b/renovate.json
@@ -22,13 +22,15 @@
   ],
   "packageRules": [
     {
-      "matchPaths": [".github/workflows/assets/bootstrap/argocd-cmp-2.8/kustomization.yaml", "examples/installation/**"],
-      "matchDepNames": ["argoproj/argo-cd"],
-      "matchUpdateTypes": ["major", "minor"],
-      "enabled": false
+      "matchPaths": [".github/workflows/assets/bootstrap/argocd-cmp-2.8/kustomization.yaml"],
+      "matchDepNames": ["argoproj/argo-cd"]
     },
     {
       "matchPaths": [".github/workflows/assets/bootstrap/argocd-cmp-2.9/kustomization.yaml", "examples/installation/**"],
+      "matchDepNames": ["argoproj/argo-cd"]
+    },
+    {
+      "matchPaths": [".github/workflows/assets/bootstrap/argocd-cmp-2.10/kustomization.yaml", "examples/installation/**"],
       "matchDepNames": ["argoproj/argo-cd"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,9 @@
   "packageRules": [
     {
       "matchPaths": [".github/workflows/assets/bootstrap/argocd-cmp-2.8/kustomization.yaml"],
-      "matchDepNames": ["argoproj/argo-cd"]
+      "matchDepNames": ["argoproj/argo-cd"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
     },
     {
       "matchPaths": [".github/workflows/assets/bootstrap/argocd-cmp-2.9/kustomization.yaml", "examples/installation/**"],


### PR DESCRIPTION
- Add Argocd 2.10 RC to CI
- Add to renovate
- Update renovate so that the installation examples track v2.9