### PR TITLE
fix(ci): update go version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: amd64
-        goversion: "https://golang.org/dl/go1.20.4.linux-amd64.tar.gz"
+        goversion: go.mod
         binary_name: "argocd-lovely-plugin"
         project_path: cmd/argocd-lovely-plugin
         extra_files: LICENSE README.md

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crumbhole/argocd-lovely-plugin
 
-go 1.22.2
+go 1.22.4
 
 require (
 	github.com/evanphx/json-patch v5.9.0+incompatible


### PR DESCRIPTION
Pull go version from go.mod for go-release-action. I think I have the syntax right from
https://github.com/wangyoucao577/go-release-action?tab=readme-ov-file#input-parameters