### PR TITLE
chore(entrypoint.sh): enable early exit

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 if [[ ! -z "${PLUGIN_NAME}" ]]; then
    /usr/local/bin/yq -i e ".metadata.name |= \"${PLUGIN_NAME}\"" /home/argocd/cmp-server/config/plugin.yaml
 fi


### PR DESCRIPTION
prevents the container from starting if the `readOnlyFilesystem` property is set to true and we are trying to modify the `plugin.yaml` name so the a custom plugin name. through unsing `set -e`, if any command in the entrypoint.sh fails, the container will stop