### PR TITLE
fix(ci): pin k3d-action to k3d v5.8.3 to fix install 404

### DIFF
--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -87,6 +87,11 @@ jobs:
         name: "Create single k3d Cluster and run Argocd/Lovely"
         with:
           cluster-name: lovely
+          # The action defaults to k3d v5.4.6, whose release has no
+          # checksums.txt asset; k3d's current install.sh requires one,
+          # so installing the default version 404s.
+          # renovate: datasource=github-releases depName=k3d-io/k3d
+          k3d-version: v5.8.3
           args: >-
             --config=.github/workflows/k3d.conf
       - name: "Deploy Argocd/Lovely"

--- a/renovate.json
+++ b/renovate.json
@@ -36,7 +36,8 @@
         "/\\.sh$/"
       ],
       "matchStrings": [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_VERSION=(?<currentValue>.*)\\s"
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_VERSION=(?<currentValue>.*)\\s",
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s+k3d-version: (?<currentValue>.*)\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }


### PR DESCRIPTION
## Summary
- CI was failing at the `AbsaOSS/k3d-action@v2` step: the action defaults to k3d v5.4.6, and k3d's current `install.sh` (fetched from `main`) now verifies downloads against a `checksums.txt` release asset that old releases like v5.4.6 don't have, so the install curls a 404.
- Pin `k3d-version: v5.8.3` in `.github/workflows/pull.yaml`. The existing `k3d.conf` (`k3d.io/v1alpha4`) is auto-migrated by k3d 5.8, so no config changes are needed.
- Add a Renovate regex matchString and a `# renovate:` annotation so the k3d pin is updated automatically going forward.

## Test plan
- [x] Verified `https://github.com/k3d-io/k3d/releases/download/v5.4.6/checksums.txt` returns 404 while v5.5.0+ return 200
- [x] Verified the new Renovate regex matches the annotated `k3d-version:` line and captures `v5.8.3`
- [x] `renovate.json` still parses as valid JSON
- [ ] CI on this PR exercises the k3d cluster job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pin the `k3d` version used during deployment testing to improve reliability and avoid issues with missing release assets.
  * Updated automated dependency tracking to recognize `k3d` version settings in more places, so future updates are detected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->