### PR TITLE
fix(ci): let renovate update kustomize in pull.yaml again

### DIFF
--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -22,8 +22,8 @@ jobs:
     - name: Install Test Dependencies
       run: |
         # https://github.com/kubernetes-sigs/kustomize/releases
-        # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize versioning=loose
-        KUSTOMIZE_VERSION=kustomize/v5.0.3
+        # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
+        KUSTOMIZE_VERSION=5.0.3
         # https://github.com/helm/helm/releases
         # renovate: datasource=github-releases depName=helm/helm
         HELM_VERSION=v3.21.4
@@ -33,7 +33,7 @@ jobs:
         # Install Helm
         curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xz linux-amd64/helm && mv linux-amd64/helm /usr/local/bin/
         # Install Kustomize
-        curl -SL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$(echo ${KUSTOMIZE_VERSION}|tr -d kustomize/)/kustomize_$(echo ${KUSTOMIZE_VERSION}|tr -d kustomize/)_linux_amd64.tar.gz | tar -xzC /usr/local/bin
+        curl -SL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | tar -xzC /usr/local/bin
         # Install Helmfile
         curl -SL https://github.com/helmfile/helmfile/releases/download/${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION:1}_linux_amd64.tar.gz | tar -xzC /usr/local/bin
 


### PR DESCRIPTION
## Summary

Renovate has silently skipped the kustomize pin in `.github/workflows/pull.yaml` since August 2023 — it is still on `v5.0.3` while the Dockerfile is on `5.8.1`.

Cause: the pin still used the pre-`extractVersion` workaround from #251, storing the full release tag (`KUSTOMIZE_VERSION=kustomize/v5.0.3` with `versioning=loose`). When the `extractVersion` package rule for `kubernetes-sigs/kustomize` was added later (68de68f), available versions started being extracted as bare semver (`5.8.1`), and the Dockerfile was migrated to a bare value — but `pull.yaml` was not. The full-tag current value can't be parsed or compared against the extracted versions, so renovate skips the dependency without complaint.

This changes `pull.yaml` to the same bare-version format the Dockerfile uses, and simplifies the download URL accordingly (verified the URL resolves). The version is intentionally left at 5.0.3 — once merged, renovate should immediately propose the catch-up to the current release, proving it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011oAJhMuybmtMA2jYL14NmS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kustomize version configuration used by automated workflows.
  * Simplified the Kustomize download process for more reliable setup.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->