### PR TITLE
feat: upgrade helm to v4, ship helm v3 as helm3

### DIFF
--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -26,7 +26,7 @@ jobs:
         KUSTOMIZE_VERSION=5.8.1
         # https://github.com/helm/helm/releases
         # renovate: datasource=github-releases depName=helm/helm
-        HELM_VERSION=v3.21.4
+        HELM_VERSION=v4.2.4
         # https://github.com/helmfile/helmfile/releases
         # renovate: datasource=github-releases depName=helmfile/helmfile
         HELMFILE_VERSION=v1.7.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,12 @@ ARG YQ_VERSION=v4.53.4
  # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
 ARG KUSTOMIZE_VERSION=5.8.1
  # https://github.com/helm/helm/releases
- # donotrenovatefornow: datasource=github-releases depName=helm/helm
-ARG HELM_VERSION=v3.21.4
+ # renovate: datasource=github-releases depName=helm/helm
+ARG HELM_VERSION=v4.2.4
+ # Helm v3, shipped alongside v4 as /usr/local/bin/helm3
+ # https://github.com/helm/helm/releases
+ # renovate: datasource=github-releases depName=helm/helm
+ARG HELM3_VERSION=v3.21.4
  # https://github.com/helmfile/helmfile/releases
  # renovate: datasource=github-releases depName=helmfile/helmfile
 ARG HELMFILE_VERSION=v1.7.4
@@ -35,6 +39,7 @@ ENV HELM_CACHE_HOME=/tmp/.helm
 ENV HELM_DATA_HOME=/tmp/.helm
 COPY --from=builder /usr/local/bin/yq /usr/local/bin/yq
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=builder /usr/local/bin/helm3 /usr/local/bin/helm3
 COPY --from=builder /usr/local/bin/helmfile /usr/local/bin/helmfile
 COPY --from=builder /usr/local/bin/kustomize /usr/local/bin/kustomize
 COPY --from=builder /build/build/argocd-lovely-plugin /usr/local/bin/argocd-lovely-plugin

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ argocd-lovely-plugin is designed for minimal configuration and to do the right t
 
 See [this](doc/parameter.md) for more details on how to configure it using parameters and a list of parameters.
 
+## Helm versions
+
+The containers use Helm v4 as the standard version of helm. Helm v3 is also included for charts that don't work with v4 yet; see [the Helm versions documentation](doc/helm3.md) for how to select it globally or per application.
+
 ## Kustomize
 
 You can use the [helm chart inflation generator](https://kubectl.docs.kubernetes.io/references/kustomize/builtins/#_helmchartinflationgenerator_) of kustomize this way. See [the test](test/helm_only_in_kustomize) for an example of this. If you do this none of the helm environment variables will have any effect as you can set those in your kustomization.yaml instead. There is no way to merge/patch your values.yaml with lovely only (you should run a preprocessor for that). Despite this, that is the recommended way to use helm and kustomize together. `LOVELY_HELM_NAME` will also have no effect here.

--- a/doc/helm3.md
+++ b/doc/helm3.md
@@ -1,0 +1,51 @@
+# Helm versions
+
+The lovely plugin containers ship two versions of Helm:
+
+- Helm v4 at `/usr/local/bin/helm`. This is the system version, and is what lovely uses by default.
+- Helm v3 at `/usr/local/bin/helm3`, for charts that do not yet work with Helm v4.
+
+## Using Helm v3 for every application
+
+Set `LOVELY_HELM_PATH` in the environment of the lovely sidecar container to make Helm v3 the default for all applications rendered by that plugin:
+
+```yaml
+containers:
+  - name: lovely-plugin
+    image: ghcr.io/crumbhole/argocd-lovely-plugin-cmp:<version>
+    env:
+      - name: LOVELY_HELM_PATH
+        value: /usr/local/bin/helm3
+```
+
+## Using Helm v3 for a single application
+
+Set `LOVELY_HELM_PATH` on the application itself, either as a plugin environment variable:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+spec:
+  source:
+    plugin:
+      name: argocd-lovely-plugin-v1.3
+      env:
+        - name: LOVELY_HELM_PATH
+          value: /usr/local/bin/helm3
+```
+
+or as a plugin parameter:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+spec:
+  source:
+    plugin:
+      name: argocd-lovely-plugin-v1.3
+      parameters:
+        - name: lovely_helm_path
+          string: /usr/local/bin/helm3
+```
+
+You don't need to prefix the environment variable with `ARGOCD_ENV_` in the application; Argo CD does that for you. If you are running lovely outside these containers, `LOVELY_HELM_PATH` can point at any Helm binary you have installed.

--- a/doc/variations.md
+++ b/doc/variations.md
@@ -1,6 +1,6 @@
 # Lovely variations
 
-All lovely plugin containers have helm, kustomize, helmfile, bash, git, and yq built in to them.
+All lovely plugin containers have helm, kustomize, helmfile, bash, git, and yq built in to them. Helm v4 is the system helm; helm v3 is also included as `helm3` — see [Helm versions](helm3.md).
 
 | Container name | Versioned | Contains |
 |----------------|-----------|----------|

--- a/renovate.json
+++ b/renovate.json
@@ -77,6 +77,14 @@
       "groupName": "docker-build-push-action"
     },
     {
+      "description": "Keep the bundled helm3 binary on the latest v3 release",
+      "matchDepNames": [
+        "helm/helm"
+      ],
+      "matchCurrentVersion": "/^v3\\./",
+      "allowedVersions": "<4.0.0"
+    },
+    {
       "matchUpdateTypes": [
         "minor",
         "patch"

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -17,6 +17,9 @@ DEST=/usr/local/bin
 # Install Helm
 curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz | tar -xz linux-${ARCH}/helm && mv linux-${ARCH}/helm ${DEST}
 
+# Install Helm v3 as helm3
+curl -SL https://get.helm.sh/helm-${HELM3_VERSION}-linux-${ARCH}.tar.gz | tar -xz linux-${ARCH}/helm && mv linux-${ARCH}/helm ${DEST}/helm3
+
 # Install Kustomize
 curl -SL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv$(echo ${KUSTOMIZE_VERSION}|tr -d kustomize/)/kustomize_v$(echo ${KUSTOMIZE_VERSION}|tr -d kustomize/)_linux_${ARCH}.tar.gz | tar -xzC ${DEST}
 

--- a/test/helm_local/expected.txt
+++ b/test/helm_local/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/charts/hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/charts/hello-world/templates/deployment.yaml
 apiVersion: apps/v1
@@ -100,3 +102,4 @@ spec:
       command: ['wget']
       args: ['test-hello-world:80']
   restartPolicy: Never
+

--- a/test/helm_merge/expected.txt
+++ b/test/helm_merge/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/charts/hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/charts/hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helm_oci/expected.txt
+++ b/test/helm_oci/expected.txt
@@ -596,6 +596,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: karpenter
       app.kubernetes.io/instance: test
+
 ---
 # Source: karpenter/charts/karpenter/templates/serviceaccount.yaml
 apiVersion: v1
@@ -623,6 +624,7 @@ metadata:
     app.kubernetes.io/version: "0.22.1"
     app.kubernetes.io/managed-by: Helm
 data: {} # Injected by karpenter-webhook
+
 ---
 # Source: karpenter/charts/karpenter/templates/configmap-logging.yaml
 apiVersion: v1
@@ -663,6 +665,7 @@ data:
       }
     }
   loglevel.webhook: "error"
+
 ---
 # Source: karpenter/charts/karpenter/templates/configmap.yaml
 apiVersion: v1
@@ -688,6 +691,7 @@ data:
   "aws.vmMemoryOverheadPercent": "0.075"
   "batchIdleDuration": "1s"
   "batchMaxDuration": "10s"
+
 ---
 # Source: karpenter/charts/karpenter/templates/aggregate-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -708,6 +712,7 @@ rules:
   - apiGroups: ["karpenter.k8s.aws"]
     resources: ["awsnodetemplates"]
     verbs: ["get", "list", "watch", "create", "delete", "patch"]
+
 ---
 # Source: karpenter/charts/karpenter/templates/clusterrole-core.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -761,6 +766,7 @@ rules:
     resources: ["mutatingwebhookconfigurations"]
     verbs: ["update"]
     resourceNames: ["defaulting.webhook.karpenter.sh"]
+
 ---
 # Source: karpenter/charts/karpenter/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -786,6 +792,7 @@ rules:
     resources: ["mutatingwebhookconfigurations"]
     verbs: ["update"]
     resourceNames: ["defaulting.webhook.karpenter.k8s.aws"]
+
 ---
 # Source: karpenter/charts/karpenter/templates/clusterrole-core.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -806,6 +813,7 @@ subjects:
   - kind: ServiceAccount
     name: test-karpenter
     namespace: testnamespace
+
 ---
 # Source: karpenter/charts/karpenter/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -826,6 +834,7 @@ subjects:
   - kind: ServiceAccount
     name: test-karpenter
     namespace: testnamespace
+
 ---
 # Source: karpenter/charts/karpenter/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -875,6 +884,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["create"]
+
 ---
 # Source: karpenter/charts/karpenter/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -894,6 +904,7 @@ rules:
     resources: ["services"]
     resourceNames: ["kube-dns"]
     verbs: ["get"]
+
 ---
 # Source: karpenter/charts/karpenter/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -915,6 +926,7 @@ subjects:
   - kind: ServiceAccount
     name: test-karpenter
     namespace: testnamespace
+
 ---
 # Source: karpenter/charts/karpenter/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -963,6 +975,7 @@ spec:
   selector:
     app.kubernetes.io/name: karpenter
     app.kubernetes.io/instance: test
+
 ---
 # Source: karpenter/charts/karpenter/templates/deployment.yaml
 apiVersion: apps/v1
@@ -1067,6 +1080,7 @@ spec:
             matchLabels:
               app.kubernetes.io/name: karpenter
               app.kubernetes.io/instance: test
+
 ---
 # Source: karpenter/charts/karpenter/templates/webhooks-core.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -1099,6 +1113,7 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+
 ---
 # Source: karpenter/charts/karpenter/templates/webhooks.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -1142,6 +1157,7 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+
 ---
 # Source: karpenter/charts/karpenter/templates/webhooks-core.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -1175,6 +1191,7 @@ webhooks:
           - CREATE
           - UPDATE
           - DELETE
+
 ---
 # Source: karpenter/charts/karpenter/templates/webhooks-core.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -1199,6 +1216,7 @@ webhooks:
     objectSelector:
       matchLabels:
         app.kubernetes.io/part-of: karpenter
+
 ---
 # Source: karpenter/charts/karpenter/templates/webhooks.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/test/helm_only/expected.txt
+++ b/test/helm_only/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/charts/hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/charts/hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helm_override_name/expected.txt
+++ b/test/helm_override_name/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: overridden
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/charts/hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: overridden
+
 ---
 # Source: hello-world/charts/hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helm_plus_additions/expected.txt
+++ b/test/helm_plus_additions/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/charts/hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/charts/hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helm_repo_add_params/expected.txt
+++ b/test/helm_repo_add_params/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/charts/hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/charts/hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helm_tplparams/expected.txt
+++ b/test/helm_tplparams/expected.txt
@@ -7978,6 +7978,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: test
     app.kubernetes.io/component: controller-manager
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8200,6 +8201,9 @@ rules:
       - patch
       - update
       - watch
+
+
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8218,6 +8222,7 @@ rules:
       - /metrics
     verbs:
       - get
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8244,6 +8249,8 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8265,6 +8272,9 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: testnamespace
+
+
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8286,6 +8296,8 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: testnamespace
+
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8328,6 +8340,7 @@ rules:
     verbs:
       - create
       - patch
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8350,6 +8363,7 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: testnamespace
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/service.yaml
 apiVersion: v1
@@ -8377,6 +8391,7 @@ spec:
   selector:
       app.kubernetes.io/name: opentelemetry-operator
       app.kubernetes.io/component: controller-manager
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/service.yaml
 apiVersion: v1
@@ -8399,6 +8414,7 @@ spec:
   selector:
       app.kubernetes.io/name: opentelemetry-operator
       app.kubernetes.io/component: controller-manager
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/deployment.yaml
 apiVersion: apps/v1
@@ -8503,47 +8519,7 @@ spec:
         runAsGroup: 65532
         runAsNonRoot: true
         runAsUser: 65532
----
-# Source: opentelemetry-operator/charts/opentelemetry-operator/templates/certmanager.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: test
-    app.kubernetes.io/component: webhook
-  name: test-opentelemetry-operator-serving-cert
-  namespace: testnamespace
-spec:
-  dnsNames:
-    - test-opentelemetry-operator-webhook.testnamespace.svc
-    - test-opentelemetry-operator-webhook.testnamespace.svc.cluster.local
-  issuerRef:
-    kind: Issuer
-    name: test-opentelemetry-operator-selfsigned-issuer
-  secretName: test-opentelemetry-operator-controller-manager-service-cert
-  subject:
-    organizationalUnits:
-      - test-opentelemetry-operator
----
-# Source: opentelemetry-operator/charts/opentelemetry-operator/templates/certmanager.yaml
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: test
-    app.kubernetes.io/component: webhook
-  name: test-opentelemetry-operator-selfsigned-issuer
-  namespace: testnamespace
-spec:
-  selfSigned: {}
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -8623,6 +8599,7 @@ webhooks:
           - pods
     sideEffects: None
     timeoutSeconds: 10
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -8721,6 +8698,50 @@ webhooks:
           - opentelemetrycollectors
     sideEffects: None
     timeoutSeconds: 10
+
+---
+# Source: opentelemetry-operator/charts/opentelemetry-operator/templates/certmanager.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.41.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/component: webhook
+  name: test-opentelemetry-operator-serving-cert
+  namespace: testnamespace
+spec:
+  dnsNames:
+    - test-opentelemetry-operator-webhook.testnamespace.svc
+    - test-opentelemetry-operator-webhook.testnamespace.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: test-opentelemetry-operator-selfsigned-issuer
+  secretName: test-opentelemetry-operator-controller-manager-service-cert
+  subject:
+    organizationalUnits:
+      - test-opentelemetry-operator
+
+---
+# Source: opentelemetry-operator/charts/opentelemetry-operator/templates/certmanager.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.41.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/component: webhook
+  name: test-opentelemetry-operator-selfsigned-issuer
+  namespace: testnamespace
+spec:
+  selfSigned: {}
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/verticalpodautoscaler.yaml
 apiVersion: autoscaling.k8s.io/v1
@@ -8783,6 +8804,7 @@ spec:
           else exit 1
           fi
   restartPolicy: Never
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
 apiVersion: v1
@@ -8820,6 +8842,7 @@ spec:
           else exit 1
           fi
   restartPolicy: Never
+
 ---
 # Source: opentelemetry-operator/charts/opentelemetry-operator/templates/tests/test-service-connection.yaml
 apiVersion: v1
@@ -8857,3 +8880,5 @@ spec:
           else exit 1
           fi
   restartPolicy: Never
+
+

--- a/test/helm_values/expected.txt
+++ b/test/helm_values/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/charts/hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/charts/hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helm_values2/expected.txt
+++ b/test/helm_values2/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/charts/hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/charts/hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helm_values_multiple/expected.txt
+++ b/test/helm_values_multiple/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/charts/hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/charts/hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helmfile_crd/expected.txt
+++ b/test/helmfile_crd/expected.txt
@@ -7978,6 +7978,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: test
     app.kubernetes.io/component: controller-manager
+
 ---
 # Source: opentelemetry-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8200,6 +8201,9 @@ rules:
       - patch
       - update
       - watch
+
+
+
 ---
 # Source: opentelemetry-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8218,6 +8222,7 @@ rules:
       - /metrics
     verbs:
       - get
+
 ---
 # Source: opentelemetry-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8244,6 +8249,8 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+
+
 ---
 # Source: opentelemetry-operator/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8265,6 +8272,9 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: default
+
+
+
 ---
 # Source: opentelemetry-operator/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8286,6 +8296,8 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: default
+
+
 ---
 # Source: opentelemetry-operator/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8328,6 +8340,7 @@ rules:
     verbs:
       - create
       - patch
+
 ---
 # Source: opentelemetry-operator/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8350,6 +8363,7 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: default
+
 ---
 # Source: opentelemetry-operator/templates/service.yaml
 apiVersion: v1
@@ -8377,6 +8391,7 @@ spec:
   selector:
       app.kubernetes.io/name: opentelemetry-operator
       app.kubernetes.io/component: controller-manager
+
 ---
 # Source: opentelemetry-operator/templates/service.yaml
 apiVersion: v1
@@ -8399,6 +8414,7 @@ spec:
   selector:
       app.kubernetes.io/name: opentelemetry-operator
       app.kubernetes.io/component: controller-manager
+
 ---
 # Source: opentelemetry-operator/templates/deployment.yaml
 apiVersion: apps/v1
@@ -8503,47 +8519,7 @@ spec:
         runAsGroup: 65532
         runAsNonRoot: true
         runAsUser: 65532
----
-# Source: opentelemetry-operator/templates/certmanager.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: test
-    app.kubernetes.io/component: webhook
-  name: test-opentelemetry-operator-serving-cert
-  namespace: default
-spec:
-  dnsNames:
-    - test-opentelemetry-operator-webhook.default.svc
-    - test-opentelemetry-operator-webhook.default.svc.cluster.local
-  issuerRef:
-    kind: Issuer
-    name: test-opentelemetry-operator-selfsigned-issuer
-  secretName: test-opentelemetry-operator-controller-manager-service-cert
-  subject:
-    organizationalUnits:
-      - test-opentelemetry-operator
----
-# Source: opentelemetry-operator/templates/certmanager.yaml
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: test
-    app.kubernetes.io/component: webhook
-  name: test-opentelemetry-operator-selfsigned-issuer
-  namespace: default
-spec:
-  selfSigned: {}
+
 ---
 # Source: opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -8623,6 +8599,7 @@ webhooks:
           - pods
     sideEffects: None
     timeoutSeconds: 10
+
 ---
 # Source: opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -8721,6 +8698,49 @@ webhooks:
           - opentelemetrycollectors
     sideEffects: None
     timeoutSeconds: 10
+
+---
+# Source: opentelemetry-operator/templates/certmanager.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.41.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/component: webhook
+  name: test-opentelemetry-operator-serving-cert
+  namespace: default
+spec:
+  dnsNames:
+    - test-opentelemetry-operator-webhook.default.svc
+    - test-opentelemetry-operator-webhook.default.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: test-opentelemetry-operator-selfsigned-issuer
+  secretName: test-opentelemetry-operator-controller-manager-service-cert
+  subject:
+    organizationalUnits:
+      - test-opentelemetry-operator
+
+---
+# Source: opentelemetry-operator/templates/certmanager.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.41.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/component: webhook
+  name: test-opentelemetry-operator-selfsigned-issuer
+  namespace: default
+spec:
+  selfSigned: {}
 ---
 # Source: opentelemetry-operator/templates/tests/test-certmanager-connection.yaml
 apiVersion: v1
@@ -8758,6 +8778,7 @@ spec:
           else exit 1
           fi
   restartPolicy: Never
+
 ---
 # Source: opentelemetry-operator/templates/tests/test-service-connection.yaml
 apiVersion: v1
@@ -8795,6 +8816,7 @@ spec:
           else exit 1
           fi
   restartPolicy: Never
+
 ---
 # Source: opentelemetry-operator/templates/tests/test-service-connection.yaml
 apiVersion: v1
@@ -8832,4 +8854,6 @@ spec:
           else exit 1
           fi
   restartPolicy: Never
+
+
 

--- a/test/helmfile_d_ayaml/expected.txt
+++ b/test/helmfile_d_ayaml/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helmfile_d_only/expected.txt
+++ b/test/helmfile_d_only/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helmfile_d_zyaml/expected.txt
+++ b/test/helmfile_d_zyaml/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helmfile_env_propagation/expected.txt
+++ b/test/helmfile_env_propagation/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helmfile_only/expected.txt
+++ b/test/helmfile_only/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helmfile_patch/expected.txt
+++ b/test/helmfile_patch/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/templates/deployment.yaml
 apiVersion: apps/v1

--- a/test/helmfile_tplparams/expected.txt
+++ b/test/helmfile_tplparams/expected.txt
@@ -7978,6 +7978,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: test
     app.kubernetes.io/component: controller-manager
+
 ---
 # Source: opentelemetry-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8200,6 +8201,9 @@ rules:
       - patch
       - update
       - watch
+
+
+
 ---
 # Source: opentelemetry-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8218,6 +8222,7 @@ rules:
       - /metrics
     verbs:
       - get
+
 ---
 # Source: opentelemetry-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8244,6 +8249,8 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+
+
 ---
 # Source: opentelemetry-operator/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8265,6 +8272,9 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: default
+
+
+
 ---
 # Source: opentelemetry-operator/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8286,6 +8296,8 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: default
+
+
 ---
 # Source: opentelemetry-operator/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8328,6 +8340,7 @@ rules:
     verbs:
       - create
       - patch
+
 ---
 # Source: opentelemetry-operator/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8350,6 +8363,7 @@ subjects:
   - kind: ServiceAccount
     name: opentelemetry-operator
     namespace: default
+
 ---
 # Source: opentelemetry-operator/templates/service.yaml
 apiVersion: v1
@@ -8377,6 +8391,7 @@ spec:
   selector:
       app.kubernetes.io/name: opentelemetry-operator
       app.kubernetes.io/component: controller-manager
+
 ---
 # Source: opentelemetry-operator/templates/service.yaml
 apiVersion: v1
@@ -8399,6 +8414,7 @@ spec:
   selector:
       app.kubernetes.io/name: opentelemetry-operator
       app.kubernetes.io/component: controller-manager
+
 ---
 # Source: opentelemetry-operator/templates/deployment.yaml
 apiVersion: apps/v1
@@ -8503,47 +8519,7 @@ spec:
         runAsGroup: 65532
         runAsNonRoot: true
         runAsUser: 65532
----
-# Source: opentelemetry-operator/templates/certmanager.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: test
-    app.kubernetes.io/component: webhook
-  name: test-opentelemetry-operator-serving-cert
-  namespace: default
-spec:
-  dnsNames:
-    - test-opentelemetry-operator-webhook.default.svc
-    - test-opentelemetry-operator-webhook.default.svc.cluster.local
-  issuerRef:
-    kind: Issuer
-    name: test-opentelemetry-operator-selfsigned-issuer
-  secretName: test-opentelemetry-operator-controller-manager-service-cert
-  subject:
-    organizationalUnits:
-      - test-opentelemetry-operator
----
-# Source: opentelemetry-operator/templates/certmanager.yaml
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  labels:
-    helm.sh/chart: opentelemetry-operator-0.41.0
-    app.kubernetes.io/name: opentelemetry-operator
-    app.kubernetes.io/version: "0.87.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: test
-    app.kubernetes.io/component: webhook
-  name: test-opentelemetry-operator-selfsigned-issuer
-  namespace: default
-spec:
-  selfSigned: {}
+
 ---
 # Source: opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -8623,6 +8599,7 @@ webhooks:
           - pods
     sideEffects: None
     timeoutSeconds: 10
+
 ---
 # Source: opentelemetry-operator/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -8721,6 +8698,50 @@ webhooks:
           - opentelemetrycollectors
     sideEffects: None
     timeoutSeconds: 10
+
+---
+# Source: opentelemetry-operator/templates/certmanager.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.41.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/component: webhook
+  name: test-opentelemetry-operator-serving-cert
+  namespace: default
+spec:
+  dnsNames:
+    - test-opentelemetry-operator-webhook.default.svc
+    - test-opentelemetry-operator-webhook.default.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: test-opentelemetry-operator-selfsigned-issuer
+  secretName: test-opentelemetry-operator-controller-manager-service-cert
+  subject:
+    organizationalUnits:
+      - test-opentelemetry-operator
+
+---
+# Source: opentelemetry-operator/templates/certmanager.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    helm.sh/chart: opentelemetry-operator-0.41.0
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/version: "0.87.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/component: webhook
+  name: test-opentelemetry-operator-selfsigned-issuer
+  namespace: default
+spec:
+  selfSigned: {}
+
 ---
 # Source: opentelemetry-operator/templates/verticalpodautoscaler.yaml
 apiVersion: autoscaling.k8s.io/v1
@@ -8783,6 +8804,7 @@ spec:
           else exit 1
           fi
   restartPolicy: Never
+
 ---
 # Source: opentelemetry-operator/templates/tests/test-service-connection.yaml
 apiVersion: v1
@@ -8820,6 +8842,7 @@ spec:
           else exit 1
           fi
   restartPolicy: Never
+
 ---
 # Source: opentelemetry-operator/templates/tests/test-service-connection.yaml
 apiVersion: v1
@@ -8857,4 +8880,6 @@ spec:
           else exit 1
           fi
   restartPolicy: Never
+
+
 

--- a/test/preprocessor/expected.txt
+++ b/test/preprocessor/expected.txt
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/version: "1.16.0"
     app.kubernetes.io/managed-by: Helm
+
 ---
 # Source: hello-world/charts/hello-world/templates/service.yaml
 apiVersion: v1
@@ -32,6 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: hello-world
     app.kubernetes.io/instance: test
+
 ---
 # Source: hello-world/charts/hello-world/templates/deployment.yaml
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary

- **Helm v4.2.4 becomes the system helm** at `/usr/local/bin/helm` in the containers and in CI, used by default (`LOVELY_HELM_PATH` unchanged).
- **Helm v3 is still shipped** at `/usr/local/bin/helm3` (pinned `HELM3_VERSION` in the Dockerfile) for charts that don't work with v4 yet.
- **New doc `doc/helm3.md`** explains how to select helm v3 globally (sidecar env `LOVELY_HELM_PATH=/usr/local/bin/helm3`) or per application (plugin `env:` or the `lovely_helm_path` parameter), linked from the README and variations doc.
- **Renovate**: the `donotrenovatefornow` guard that held v4 back is replaced with a normal renovate comment; a new package rule (`matchCurrentVersion: /^v3\./`, `allowedVersions: <4.0.0`) keeps the bundled helm3 on the latest v3 release while the system helm updates freely.
- **Test expectations regenerated** for helm v4: v4 preserves each template's trailing newlines where v3 trimmed them, and sorts kinds unknown to its install-order (cert-manager `Certificate`/`Issuer`) after known kinds. All 20 affected `expected.txt` diffs are whitespace and document-order only — verified the sorted non-blank line sets are identical to the previous expectations.

## Testing

Full `go test ./...` passes locally with the exact CI/container toolchain: helm v4.2.4, helmfile v1.7.4, kustomize v5.8.1. Requires kustomize ≥ v5.8 (#1000, already on main) since older kustomize invokes `helm version -c`, a flag removed in helm v4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011oAJhMuybmtMA2jYL14NmS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Helm 4.2.4 is now the default Helm version.
  * Helm 3.21.4 remains available as a fallback through a separate `helm3` command.
  * Added configuration options for selecting Helm 3 globally or per application.

* **Documentation**
  * Added guidance on available Helm versions and how to choose between them.

* **Tests**
  * Updated rendered manifest expectations for improved YAML spacing and resource ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->